### PR TITLE
chore(release): Add missing semantic-release exec dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "17.8.1",
     "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.1",
     "@semantic-release/npm": "^12.0.1",


### PR DESCRIPTION
This PR adds the missing @semantic-release/exec dependency which is required for our semantic-release configuration to work properly with version bumping in the monorepo setup.

- Added @semantic-release/exec as a devDependency
- This should fix the version bumping issues we were experiencing