### PR TITLE
chore(root): Update version update script to use YAML parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.1.7",
+    "js-yaml": "^4.1.0",
     "lint-staged": "^15.3.0",
     "prettier": "^3.4.2",
     "semantic-release": "^24.2.1",

--- a/scripts/update-package-versions.js
+++ b/scripts/update-package-versions.js
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { load } from 'js-yaml';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,7 +16,7 @@ if (!newVersion) {
 const rootDir = join(__dirname, '..');
 
 // Read workspace configuration
-const workspaceConfig = JSON.parse(
+const workspaceConfig = load(
   readFileSync(join(rootDir, 'pnpm-workspace.yaml'), 'utf8')
 );
 
@@ -24,7 +25,11 @@ const packagePaths = workspaceConfig.packages.filter(p => !p.startsWith('#'));
 
 // Update version in each package.json
 for (const packagePath of packagePaths) {
-  const packageJsonPath = join(rootDir, packagePath, 'package.json');
+  const packageJsonPath = join(
+    rootDir,
+    packagePath.replace('/*', ''),
+    'package.json'
+  );
   try {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
     packageJson.version = newVersion;


### PR DESCRIPTION
This PR updates the version update script to properly handle YAML files:

- Use js-yaml for parsing workspace configuration
- Handle glob patterns in package paths correctly
- Add js-yaml as a dev dependency

This change fixes the semantic-release process by ensuring the script can properly read the pnpm-workspace.yaml file.