### PR TITLE
fix: Add UI package to workspace for version management

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,8 +16,6 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "class-variance-authority": "^0.7.0",
-    "clsx": "^2.0.0",
-    "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
@@ -25,9 +23,11 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.16",
+    "clsx": "^2.1.1",
     "postcss": "^8.4.32",
     "react": "^18.2.0",
     "rimraf": "^5.0.5",
+    "tailwind-merge": "^2.6.0",
     "tailwindcss": "^3.4.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/frontend'
   - 'packages/backend'
   - 'packages/shared'
+  - 'packages/ui'
   # Optional packages
   - 'packages/admin-portal'
   - 'packages/landing-page'


### PR DESCRIPTION
This PR adds the UI package to the workspace configuration to ensure it gets properly versioned during releases. This will trigger a patch release that will bring the UI package up to date with the other packages.